### PR TITLE
Slideshow: fix incompatible cell context menu context

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-jupyter-slideshow",
     "displayName": "Jupyter Slide Show",
     "description": "Jupyter Slide Show support for VS Code",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "publisher": "ms-toolsai",
     "preview": true,
     "icon": "icon.png",


### PR DESCRIPTION
The cell context menu and cell toolbar are not using the same context right now, this is a hot fix for the extension. We will align the context in the core next iteration.